### PR TITLE
Verify email before sending confirmation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "dotenv": "^16.4.5",
         "express": "^4.18.2",
         "googleapis": "^118.0.0",
+        "nodemailer": "^6.10.1",
         "twilio": "^4.14.0"
       },
       "engines": {
@@ -1066,6 +1067,15 @@
       "license": "(BSD-3-Clause OR GPL-2.0)",
       "engines": {
         "node": ">= 6.13.0"
+      }
+    },
+    "node_modules/nodemailer": {
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.10.1.tgz",
+      "integrity": "sha512-Z+iLaBGVaSjbIzQ4pX6XV41HrooLsQ10ZWPUehGmuantvzWoDVBnmsdUcOIDM1t+yPor5pDhVlDESgOMEGxhHA==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/object-inspect": {

--- a/package.json
+++ b/package.json
@@ -7,9 +7,10 @@
     "start": "node index.js"
   },
   "dependencies": {
+    "dotenv": "^16.4.5",
     "express": "^4.18.2",
     "googleapis": "^118.0.0",
-    "dotenv": "^16.4.5",
+    "nodemailer": "^6.10.1",
     "twilio": "^4.14.0"
   },
   "engines": {


### PR DESCRIPTION
## Summary
- prompt the caller to confirm the transcribed email address
- send confirmation email only after the user says it is correct
- default sender is now kurtwaynewilson@gmail.com

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6882a13868c88329957c3e2b504e8388