### PR TITLE
Improve email capture handling

### DIFF
--- a/index.js
+++ b/index.js
@@ -251,6 +251,8 @@ function parseDate(str) {
 function parseSpokenEmail(text) {
   return text
     .toLowerCase()
+    // remove common leading phrases like "my email is", "it's", etc.
+    .replace(/(?:my\s+email(?:\s+address)?\s+is|the\s+email(?:\s+address)?\s+is|email(?:\s+address)?\s+is|it's|it\s+is|this\s+is)[:\s]*/g, '')
     .replace(/\s+at\s+/g, '@')
     .replace(/\s+dot\s+/g, '.')
     .replace(/\s+underscore\s+/g, '_')


### PR DESCRIPTION
## Summary
- improve recognition of spoken email addresses by stripping filler phrases

## Testing
- `node - <<'NODE'
const parse = text => text
  .toLowerCase()
  .replace(/(?:my\s+email(?:\s+address)?\s+is|the\s+email(?:\s+address)?\s+is|email(?:\s+address)?\s+is|it's|it\s+is|this\s+is)[:\s]*/g, '')
  .replace(/\s+at\s+/g, '@')
  .replace(/\s+dot\s+/g, '.')
  .replace(/\s+underscore\s+/g, '_')
  .replace(/\s+(?:dash|hyphen)\s+/g, '-')
  .replace(/\s+/g, '');
console.log(parse("my email is john dot doe at gmail dot com"));
console.log(parse("it's jane at yahoo dot com"));
console.log(parse("the email is: test dot user at outlook dot com"));
NODE

------
https://chatgpt.com/codex/tasks/task_e_68839f78f6a48329953245143e370d41