### PR TITLE
Add logging before email send

### DIFF
--- a/index.js
+++ b/index.js
@@ -235,6 +235,8 @@ app.post('/voice', async (req, res) => {
       twiml.say('Thanks! A confirmation email has been sent. Goodbye.');
       res.type('text/xml').send(twiml.toString());
 
+      console.log('Email confirmed:', session.data.email, 'Call SID:', callSid);
+
       transporter
         .sendMail({
           from: 'lwwilsoncontainerhomes@gmail.com',


### PR DESCRIPTION
## Summary
- add debug log prior to sending confirmation email

## Testing
- `node -c index.js`


------
https://chatgpt.com/codex/tasks/task_e_688404109cc48329a6b73757bc4ca51b