### PR TITLE
Fix spelled name with hyphen

### DIFF
--- a/index.js
+++ b/index.js
@@ -283,7 +283,12 @@ function parseSpokenName(text) {
 
   if (!cleaned) return null;
 
-  const rawTokens = cleaned.split(/\s+/);
+  const rawTokens = cleaned.split(/\s+/).flatMap(tok => {
+    if (/^[a-z](?:-[a-z])+$/i.test(tok)) {
+      return tok.split('-');
+    }
+    return tok;
+  });
 
   // Map common letter words and homophones to their single letter equivalent
   const letterMap = {

--- a/test/parseSpokenName.test.js
+++ b/test/parseSpokenName.test.js
@@ -8,6 +8,8 @@ const cases = [
   ['k a y', 'K'],
   ['bee cee', 'Bc'],
   ['why', 'Y'],
+  ['the name is carrigan c-a-r-r-i-g-a-n', 'Carrigan'],
+  ['c-a-r-r-i-g-a-n', 'Carrigan'],
 ];
 
 for (const [input, expected] of cases) {


### PR DESCRIPTION
## Summary
- handle tokens that are single letters separated by hyphens when parsing spoken names
- extend tests for hyphenated spelling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6884077100948329840650462cf3588c