### PR TITLE
Fix parsing of "double you" names/emails

### DIFF
--- a/index.js
+++ b/index.js
@@ -350,7 +350,7 @@ function parseSpokenName(text) {
     t: 't', tee: 't',
     u: 'u', you: 'u',
     v: 'v', vee: 'v',
-    w: 'w',
+    w: 'w', 'doubleu': 'w', 'double-you': 'w',
     x: 'x', ex: 'x',
     y: 'y', why: 'y',
     z: 'z', zee: 'z', zed: 'z'
@@ -360,6 +360,11 @@ function parseSpokenName(text) {
   const tokens = [];
   for (let i = 0; i < expandedTokens.length; i++) {
     let tok = expandedTokens[i];
+    if (tok === 'double' && i + 1 < expandedTokens.length && (expandedTokens[i + 1] === 'u' || expandedTokens[i + 1] === 'you')) {
+      tokens.push('doubleu');
+      i += 1;
+      continue;
+    }
     if (i + 2 < expandedTokens.length && /^[a-z]$/.test(expandedTokens[i]) && /^[a-z]$/.test(expandedTokens[i + 1]) && /^[a-z]$/.test(expandedTokens[i + 2])) {
       const tri = expandedTokens[i] + expandedTokens[i + 1] + expandedTokens[i + 2];
       if (letterMap[tri]) {
@@ -439,7 +444,13 @@ function parseSpokenEmail(text) {
     }
   };
 
-  for (const t of tokens) {
+  for (let i = 0; i < tokens.length; i++) {
+    const t = tokens[i];
+    if (t === 'double' && i + 1 < tokens.length && (tokens[i + 1] === 'u' || tokens[i + 1] === 'you')) {
+      letters.push('w');
+      i += 1;
+      continue;
+    }
     const mapped = wordToLetter[t];
     if (mapped) {
       letters.push(mapped);

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "start": "node index.js",
-    "test": "node test/parseSpokenName.test.js && node test/parseDateRange.test.js"
+    "test": "node test/parseSpokenName.test.js && node test/parseDateRange.test.js && node test/parseSpokenEmail.test.js"
   },
   "dependencies": {
     "dotenv": "^16.4.5",

--- a/test/parseSpokenEmail.test.js
+++ b/test/parseSpokenEmail.test.js
@@ -1,0 +1,16 @@
+const assert = require('assert');
+process.env.GOOGLE_SERVICE_ACCOUNT_BASE64 = Buffer.from('{}').toString('base64');
+const { parseSpokenEmail } = require('../index');
+
+const cases = [
+  ['john dot doe at gmail dot com', 'john.doe@gmail.com'],
+  ['jane at example dot com', 'jane@example.com'],
+  ['double you at test dot com', 'w@test.com'],
+  ['double u at example dot com', 'w@example.com'],
+];
+
+for (const [input, expected] of cases) {
+  const result = parseSpokenEmail(input);
+  assert.strictEqual(result, expected, `${input} -> ${result}`);
+}
+console.log('parseSpokenEmail tests passed');

--- a/test/parseSpokenName.test.js
+++ b/test/parseSpokenName.test.js
@@ -9,6 +9,8 @@ const cases = [
   ['bee cee', 'Bc'],
   ['why', 'Y'],
   ['the name is carrigan c-a-r-r-i-g-a-n', 'Carrigan'],
+  ['double you', 'W'],
+  ['double u', 'W'],
 
 ];
 


### PR DESCRIPTION
## Summary
- handle phrases like "double you" and "double u" when parsing spelled names
- treat the same phrases when parsing spoken email addresses
- add regression tests for the new cases and add a new test file

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688422f360988329b1fdffe9a409dd64