### PR TITLE
Fix email parsing with spaces

### DIFF
--- a/index.js
+++ b/index.js
@@ -498,6 +498,12 @@ function parseSpokenEmail(text) {
   }
 
   result = result.trim();
+  const atIndex = result.indexOf('@');
+  if (atIndex > 0) {
+    const before = result.slice(0, atIndex).replace(/\s+/g, '');
+    result = before + result.slice(atIndex);
+  }
+
   const match = result.match(/[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}/i);
   return match ? match[0] : result.replace(/\s+/g, '');
 }

--- a/test/parseSpokenEmail.test.js
+++ b/test/parseSpokenEmail.test.js
@@ -7,6 +7,7 @@ const cases = [
   ['jane at example dot com', 'jane@example.com'],
   ['double you at test dot com', 'w@test.com'],
   ['double u at example dot com', 'w@example.com'],
+  ['kurt wayne wilson at gmail dot com', 'kurtwaynewilson@gmail.com'],
 ];
 
 for (const [input, expected] of cases) {


### PR DESCRIPTION
## Summary
- correct parseSpokenEmail so spaces before `@` are ignored
- test parsing for "kurt wayne wilson at gmail dot com"

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68869436ce208329bc80a1d5fd335ce1