### PR TITLE
Improve name recognition

### DIFF
--- a/index.js
+++ b/index.js
@@ -329,6 +329,9 @@ function parseSpokenName(text) {
 
   if (!cleaned) return null;
 
+  const filler = /^(?:yes|yeah|yep|yup|okay|ok|sure|no|i\s+don'?t\s+know|don't\s+know|not\s+sure|unknown|n\/?a|uh|um)$/i;
+  if (filler.test(cleaned)) return null;
+
   const rawTokens = cleaned.split(/\s+/).flatMap(tok => {
     if (/^[a-z](?:-[a-z])+$/i.test(tok)) {
       return tok.split('-');

--- a/test/parseSpokenName.test.js
+++ b/test/parseSpokenName.test.js
@@ -11,6 +11,8 @@ const cases = [
   ['the name is carrigan c-a-r-r-i-g-a-n', 'Carrigan'],
   ['double you', 'W'],
   ['double u', 'W'],
+  ['yes', null],
+  ["i don't know", null],
 
 ];
 


### PR DESCRIPTION
## Summary
- tweak `parseSpokenName` to ignore filler words
- add tests for invalid name phrases

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6886a23f560c8329b93d1f797e8755c0