### PR TITLE
Improve name parsing

### DIFF
--- a/index.js
+++ b/index.js
@@ -378,7 +378,10 @@ function parseDateRange(text) {
 function parseSpokenName(text) {
   let cleaned = text
     .toLowerCase()
-    .replace(/(?:my\s+name\s+is|the\s+name\s+is|name\s+is|this\s+is|it's|it\s+is)\s*/g, '')
+    .replace(
+      /(?:my\s+name\s+is|the\s+name\s+is|name\s+is|the\s+name\s+(?:for\s+(?:the\s+)?(?:reservation|booking)|on\s+(?:the\s+)?(?:reservation|booking))\s+is|the\s+(?:reservation|booking)\s+is\s+under|this\s+is|it's|it\s+is)\s*/g,
+      ''
+    )
     .replace(/[.,?!]/g, ' ')
     .replace(/\b(spelled|spell|spelling)\b/g, '')
     .trim();

--- a/test/parseSpokenName.test.js
+++ b/test/parseSpokenName.test.js
@@ -11,6 +11,8 @@ const cases = [
   ['the name is carrigan c-a-r-r-i-g-a-n', 'Carrigan'],
   ['double you', 'W'],
   ['double u', 'W'],
+  ['the name for the reservation is john', 'John'],
+  ['the reservation is under george', 'George'],
   ['yes', null],
   ["i don't know", null],
 


### PR DESCRIPTION
## Summary
- support more spoken phrases for names
- add tests for additional name variants

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6887a3179f588329a55badef6e9377bc