### PR TITLE
Improve date parsing and add setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,32 @@ detects a match.
 When a call begins you'll first be asked which property you want to book—the
 **Jalapeno** or **The Bluebonnet**. Respond with the property name so the system
 can continue with collecting your dates and other details.
+
+## Getting Started
+
+1. Install dependencies:
+
+   ```bash
+   npm install
+   ```
+
+2. Set the required environment variables:
+
+   - `GOOGLE_SERVICE_ACCOUNT_BASE64` – base64 encoded Google service account JSON
+   - `GOOGLE_CALENDAR_ID` – the calendar ID where bookings will be created
+   - `EMAIL_PASS` – password for the email account used to send confirmations
+   - `EMAIL_USER` *(optional)* – sender email address (defaults to `lwwilsoncontainerhomes@gmail.com`)
+
+3. Start the server:
+
+   ```bash
+   npm start
+   ```
+
+## Running Tests
+
+Run the unit tests with:
+
+```bash
+npm test
+```

--- a/index.js
+++ b/index.js
@@ -353,7 +353,15 @@ function parseDate(str) {
   if (Number.isNaN(temp.getTime())) return null;
   const month = temp.getUTCMonth();
 
-  const year = new Date().getUTCFullYear();
+  const now = new Date();
+  let year = now.getUTCFullYear();
+  const currentMonth = now.getUTCMonth();
+  const currentDay = now.getUTCDate();
+
+  if (month < currentMonth || (month === currentMonth && day < currentDay)) {
+    year += 1; // assume booking for next year if date has already passed
+  }
+
   const date = new Date(Date.UTC(year, month, day));
   if (date.getUTCDate() !== day || date.getUTCMonth() !== month) return null;
 


### PR DESCRIPTION
## Summary
- handle next-year dates in `parseDate`
- document setup steps in README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6887c72eedd48329b301c66fada6bfed