### PR TITLE
Add confirmation text option

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,11 @@
 
    - `GOOGLE_SERVICE_ACCOUNT_BASE64` – base64 encoded Google service account JSON
    - `GOOGLE_CALENDAR_ID` – the calendar ID where bookings will be created
+   - `TWILIO_ACCOUNT_SID` – your Twilio account SID
+   - `TWILIO_AUTH_TOKEN` – your Twilio auth token
+   - `TWILIO_PHONE_NUMBER` – the Twilio phone number used to send texts
+
+   When a booking is confirmed, callers will be prompted to receive a confirmation text message sent from this number.
 
 3. Start the server:
 


### PR DESCRIPTION
## Summary
- ask callers if they want a confirmation text after booking
- send SMS if user agrees using new Twilio env vars
- document Twilio configuration in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6887ec9c35fc83299cfb51c6c4253183