### PR TITLE
Require explicit date ranges

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ async function finalizeBooking(session) {
   const [startDate, endDate] = session.data.dates;
 
   const isoStart = parseDate(startDate);
-  const isoEnd = parseDate(endDate || startDate);
+  const isoEnd = parseDate(endDate);
   if (!isoStart || !isoEnd) {
     throw new Error('Invalid date');
   }
@@ -59,7 +59,7 @@ async function finalizeBooking(session) {
     resource: event,
   });
 
-  return { startDate, endDate: endDate || startDate };
+  return { startDate, endDate };
 }
 
 app.post('/voice', async (req, res, next) => {
@@ -99,10 +99,10 @@ app.post('/voice', async (req, res, next) => {
   // Step 0: Ask for Dates
   if (session.step === 0) {
     const dates = parseDateRange(userSpeech);
-    if (dates && dates.length >= 1) {
+    if (dates && dates.length === 2) {
       const [startDate, endDate] = dates;
       const isoStart = parseDate(startDate);
-      const isoEnd = parseDate(endDate || startDate);
+      const isoEnd = parseDate(endDate);
       if (!isoStart || !isoEnd) {
         return ask("I couldn't understand those dates. Could you repeat the check-in and check-out dates?");
       }
@@ -142,7 +142,7 @@ app.post('/voice', async (req, res, next) => {
       session.step = 1;
       return ask("Great. How many guests will be staying?");
     } else {
-      return ask("Sorry, I didn’t catch the dates. Can you say the check-in and check-out dates again?");
+      return ask("Sorry, I didn’t catch both dates. Can you say the check-in and check-out dates again?");
     }
   }
 
@@ -376,12 +376,10 @@ function parseDateRange(text) {
   const startDay = m[2];
   const endMonth = m[3] || startMonth;
   const endDay = m[4];
+  if (!endDay) return null;
   const start = `${startMonth} ${startDay}`;
-  if (endDay) {
-    const end = `${endMonth} ${endDay}`;
-    return [start, end];
-  }
-  return [start];
+  const end = `${endMonth} ${endDay}`;
+  return [start, end];
 }
 
 function parseSpokenName(text) {

--- a/test/parseDateRange.test.js
+++ b/test/parseDateRange.test.js
@@ -2,16 +2,23 @@ const assert = require('assert');
 process.env.GOOGLE_SERVICE_ACCOUNT_BASE64 = Buffer.from('{}').toString('base64');
 const { parseDateRange } = require('../index');
 
-const cases = [
+const validCases = [
   ['august 10th through the 12th', ['august 10', 'august 12']],
   ['august 10 to august 12', ['august 10', 'august 12']],
   ['from august 10th until the 12th', ['august 10', 'august 12']],
-  ['august 10', ['august 10']],
   ['july 30th through august first', ['july 30', 'august 1']],
 ];
 
-for (const [input, expected] of cases) {
+const invalidCases = ['august 10'];
+
+for (const [input, expected] of validCases) {
   const result = parseDateRange(input);
   assert.deepStrictEqual(result, expected, `${input} -> ${JSON.stringify(result)}`);
 }
+
+for (const input of invalidCases) {
+  const result = parseDateRange(input);
+  assert.strictEqual(result, null, `${input} should be null but was ${JSON.stringify(result)}`);
+}
+
 console.log('parseDateRange tests passed');


### PR DESCRIPTION
## Summary
- Ensure booking only proceeds when both start and end dates are provided
- Tighten `parseDateRange` to return null if a second date is missing
- Expand date range tests for valid and invalid cases

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688ce67db55083298a8b1ad77a597d63