### PR TITLE
Improve yes/no interpretation

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "start": "node index.js",
-    "test": "node test/parseSpokenName.test.js && node test/parseDateRange.test.js"
+    "test": "node test/parseSpokenName.test.js && node test/parseDateRange.test.js && node test/interpretYesNo.test.js"
   },
   "dependencies": {
     "dotenv": "^16.4.5",

--- a/test/interpretYesNo.test.js
+++ b/test/interpretYesNo.test.js
@@ -1,0 +1,23 @@
+process.env.GOOGLE_SERVICE_ACCOUNT_BASE64 = Buffer.from('{}').toString('base64');
+const { interpretYesNo } = require('..');
+
+function assertEqual(actual, expected, message) {
+  if (actual !== expected) {
+    console.error(`${message} - expected ${expected}, got ${actual}`);
+    process.exit(1);
+  }
+}
+
+const cases = [
+  { input: "yes that's correct", expected: true },
+  { input: "no that's not correct", expected: false },
+  { input: "nah that's wrong", expected: false },
+  { input: "yeah sure", expected: true },
+  { input: "nope correct", expected: false },
+];
+
+cases.forEach((c, i) => {
+  assertEqual(interpretYesNo(c.input), c.expected, `Case ${i + 1}`);
+});
+
+console.log('interpretYesNo tests passed');


### PR DESCRIPTION
## Summary
- add `interpretYesNo` to handle conflicting confirmations like "no that's not correct"
- integrate the helper into name and text confirmation steps
- add test coverage for yes/no detection

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688e5eb24b588329af69bbc174866588